### PR TITLE
Added aliases for deploy:jar and deploy:war

### DIFF
--- a/commands/deploy/jar.js
+++ b/commands/deploy/jar.js
@@ -6,17 +6,17 @@ const path = require('path');
 const fs = require('fs');
 const helpers = require('../../lib/helpers')
 
-module.exports = function(topic) {
+module.exports = function(topic, command) {
   return {
     topic: topic,
-    command: 'jar',
+    command: command,
     flags: [
         { name: 'jar', char: 'j', hasValue: true },
         { name: 'jdk', hasValue: true },
         { name: 'includes', char: 'i', hasValue: true },
         { name: 'options', char: 'o', hasValue: true}],
     variableArgs: true,
-    usage: 'deploy:jar JAR',
+    usage: `${topic}:${command} JAR`,
     description: 'Deploys an executable JAR file to Heroku.',
     needsApp: true,
     needsAuth: true,

--- a/commands/deploy/war.js
+++ b/commands/deploy/war.js
@@ -6,17 +6,17 @@ const path = require('path');
 const fs = require('fs');
 const helpers = require('../../lib/helpers')
 
-module.exports = function(topic) {
+module.exports = function(topic, command) {
   return {
     topic: topic,
-    command: 'war',
+    command: command,
     flags: [
         { name: 'war', char: 'w', hasValue: true },
         { name: 'jdk', char: 'j', hasValue: true },
         { name: 'includes', char: 'i', hasValue: true },
         { name: 'webapp-runner', hasValue: true}],
     variableArgs: true,
-    usage: 'deploy:war WAR',
+    usage: `${topic}:${command} WAR`,
     description: 'Deploys a WAR file to Heroku.',
     needsApp: true,
     needsAuth: true,

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ exports.topics = [
 ]
 
 exports.commands = [
-  require('./commands/deploy/war')('deploy'),
-  require('./commands/deploy/jar')('deploy'),
+  require('./commands/deploy/war')('deploy', 'war'),
+  require('./commands/deploy/jar')('deploy', 'jar'),
+  require('./commands/deploy/war')('war', 'deploy'),
+  require('./commands/deploy/jar')('jar', 'deploy'),
 ]

--- a/test/jar/deploy.test.js
+++ b/test/jar/deploy.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const assert = require('chai').assert;
+const compareSync = require('dir-compare').compareSync;
+const path = require('path');
+const fs = require('fs-extra');
+const child = require('child_process');
+const os = require('os');
+const Heroku = require('heroku-client');
+const heroku = new Heroku({ token: apiKey });
+const expect = require('unexpected');
+const tmp = require('tmp');
+
+const jar = commands.find((c) => c.topic === 'jar' && c.command === 'deploy')
+
+describe('jar', function() {
+  this.timeout(0);
+
+  beforeEach(() => {
+    cli.mockConsole();
+    cli.exit.mock();
+  });
+
+  beforeEach(function() {
+    return heroku.post('/apps').then((app) => {
+      this.app = app;
+      console.log(`Created ${ this.app.name }`);
+    });
+  });
+
+  afterEach(function() {
+    return heroku.delete(`/apps/${ this.app.name }`).then(() => {
+      console.log(`Deleted ${ this.app.name }`);
+    });
+  });
+
+  describe('when a jar file and valid app is specified', function() {
+    it('deploys successfully', function() {
+      let config = {
+        debug: true,
+        auth: {password: apiKey},
+        args: [ path.join('test', 'fixtures', 'sample-jar.jar') ],
+        flags: {},
+        app: this.app.name
+      };
+
+      return jar.run(config)
+         .then(() => expect(cli.stdout, 'to contain', 'Uploading sample-jar.jar'))
+         .then(() => expect(cli.stdout, 'to contain', 'Installing OpenJDK 1.8'))
+         .then(() => expect(cli.stdout, 'to contain', 'deployed to Heroku'))
+         .then(() => cli.got(`https://${this.app.name}.herokuapp.com`)
+            .then(response => expect(response.body, 'to contain', 'Hello from Java!')))
+    });
+  });
+});

--- a/test/war/deploy.test.js
+++ b/test/war/deploy.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const assert = require('chai').assert;
+const compareSync = require('dir-compare').compareSync;
+const path = require('path');
+const fs = require('fs-extra');
+const child = require('child_process');
+const os = require('os');
+const Heroku = require('heroku-client');
+const heroku = new Heroku({ token: apiKey });
+const expect = require('unexpected');
+const tmp = require('tmp');
+
+const war = commands.find((c) => c.topic === 'war' && c.command === 'deploy')
+
+describe('war', function() {
+  this.timeout(0);
+
+  beforeEach(() => {
+    cli.mockConsole();
+    cli.exit.mock();
+  });
+
+  beforeEach(function() {
+    return heroku.post('/apps').then((app) => {
+      this.app = app;
+      console.log(`Created ${ this.app.name }`);
+    });
+  });
+
+  afterEach(function() {
+    return heroku.delete(`/apps/${ this.app.name }`).then(() => {
+      console.log(`Deleted ${ this.app.name }`);
+    });
+  });
+
+  describe('when a war file and valid app is specified', function() {
+    it('deploys successfully', function() {
+      let config = {
+        debug: true,
+        auth: {password: apiKey},
+        args: [ path.join('test', 'fixtures', 'sample-war.war') ],
+        flags: {},
+        app: this.app.name
+      };
+
+      return war.run(config)
+         .then(() => expect(cli.stdout, 'to contain', 'Uploading sample-war.war'))
+         .then(() => expect(cli.stdout, 'to contain', 'Installing OpenJDK 1.8'))
+         .then(() => expect(cli.stdout, 'to contain', 'deployed to Heroku'))
+         .then(() => cli.got(`https://${this.app.name}.herokuapp.com`)
+            .then(response => expect(response.body, 'to contain', 'Hello World!')))
+    });
+  });
+});


### PR DESCRIPTION
This is first step toward migrating users away from `deploy:war` and towards `war:deploy`. This will facilitate a new `war:run` command for running a WAR file locally the same way it runs on Heroku (which makes more sense than `run:war`).