### PR TITLE
specify files to pack to avoid oclif warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
   ],
   "author": "Joe Kutner <joe@heroku.com>",
   "license": "ISC",
+  "files": [
+    "/index.js",
+    "/commands",
+    "/lib"
+  ],
   "dependencies": {
     "heroku-cli-util": "^6.0.14"
   },


### PR DESCRIPTION
this attribute is now required in plugins otherwise a warning is displayed (though notably, the plugins still work fine with the warning)

See my blog post for the reason why this is now required: https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d

for other plugins, if you run `npm pack; tar -xvzf *.tgz; rm -rf package *.tgz` that will print the files it's currently packing