### PR TITLE
Use https to download webapp runner from mavencentral

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -90,7 +90,7 @@ function runWebappRunner(context, warFile, args) {
 }
 
 function _downloadWebappRunner(version, callback) {
-  let url = `http://central.maven.org/maven2/com/github/jsimone/webapp-runner/${version}/webapp-runner-${version}.jar`
+  let url = `https://central.maven.org/maven2/com/github/jsimone/webapp-runner/${version}/webapp-runner-${version}.jar`
   let file = path.join('target', `webapp-runner-${version}.jar`)
   if (fs.existsSync(file)) {
     callback(file);


### PR DESCRIPTION
> Effective January 15, 2020, The Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS.

https://support.sonatype.com/hc/en-us/articles/360041287334